### PR TITLE
Allow customisation of output file directory

### DIFF
--- a/R/build_heatmaps.R
+++ b/R/build_heatmaps.R
@@ -7,7 +7,8 @@ build.heatmaps <-
              newWindow.heatmaps = FALSE,
              output.files = FALSE,
              labels = FALSE,
-             only.MEMheatmap = FALSE) {
+             only.MEMheatmap = FALSE,
+             output.dir = "output files") {
         dendro_var_MEM = cluster.MEM
         dendro_var_med = cluster.medians
         dendro_var_IQR = cluster.IQRs
@@ -305,14 +306,12 @@ build.heatmaps <-
                     )
             }
         }
-        dir.create(file.path(getwd(), "output files"), showWarnings = FALSE)
+        dir.create(file.path(getwd(), output.dir), showWarnings = FALSE)
         if (output.files == TRUE) {
             # #         # Generate pdfs from MEM heatmap plot
-            pdf(paste(
-                "./output files/",
-                strftime(Sys.time(), "%Y-%m-%d_%H%M%S"),
-                " MEM heatmap.pdf"
-            ),
+            pdf(file.path(output.dir,
+                          paste0(strftime(Sys.time(), "%Y-%m-%d_%H%M%S"),
+                                 " MEM heatmap.pdf")),
             width = 10)
             heatmap.2(
                 heatmap_data,
@@ -340,34 +339,25 @@ build.heatmaps <-
             # Write data to text files
             write.table(
                 as.matrix(clustered_matrix),
-                paste(
-                    "./output files/",
-                    strftime(Sys.time(), "%Y-%m-%d_%H%M%S"),
-                    " MEM matrix.txt",
-                    sep = ""
-                ),
+                file.path(output.dir,
+                          paste0(strftime(Sys.time(), "%Y-%m-%d_%H%M%S"),
+                                 " MEM matrix.txt")),
                 sep = "\t",
                 row.names = TRUE
             )
             write.table(
                 as.matrix(reorder_medians),
-                paste(
-                    "./output files/",
-                    strftime(Sys.time(), "%Y-%m-%d_%H%M%S"),
-                    " Medians matrix.txt",
-                    sep = ""
-                ),
+                file.path(output.dir,
+                          paste0(strftime(Sys.time(), "%Y-%m-%d_%H%M%S"),
+                                 " Medians matrix.txt")),
                 sep = "\t",
                 row.names = TRUE
             )
             write.table(
                 as.matrix(reorder_IQR),
-                paste(
-                    "./output files/",
-                    strftime(Sys.time(), "%Y-%m-%d_%H%M%S"),
-                    " IQRs matrix.txt",
-                    sep = ""
-                ),
+                file.path(output.dir,
+                          paste0(strftime(Sys.time(), "%Y-%m-%d_%H%M%S"),
+                                 " IQRs matrix.txt")),
                 sep = "\t",
                 row.names = TRUE
             )
@@ -375,11 +365,9 @@ build.heatmaps <-
             if (((exp_data[[6]])[[1]]) == 0){
                 write.table(
                     enrichment_score_ordered,
-                    paste(
-                        "./output files/",
-                        strftime(Sys.time(), "%Y-%m-%d_%H%M%S"),
-                        " enrichment score-rownames.txt"
-                    ),
+                    file.path(output.dir,
+                              paste0(strftime(Sys.time(), "%Y-%m-%d_%H%M%S"),
+                                     " enrichment score-rownames.txt")),
                     sep = "\t"
                 )
             }else{
@@ -391,11 +379,9 @@ build.heatmaps <-
                 colnames(new_rownames_filenames) <- c("File", "MEM label")
                 write.table(
                     new_rownames_filenames,
-                    paste(
-                        "./output files/",
-                        strftime(Sys.time(), "%Y-%m-%d_%H%M%S"),
-                        " enrichment score-rownames.txt"
-                    ),
+                    file.path(output.dir,
+                              paste0(strftime(Sys.time(), "%Y-%m-%d_%H%M%S"),
+                                     " enrichment score-rownames.txt")),
                     sep = "\t"
                 )
             }


### PR DESCRIPTION
I'd like to be able to customise the output location for MEM, so that I can create output directories based on the current date; this change should allow that by creating a new variable, output.dir, which specifies the place files are put (defaults to "output dir").